### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ It allows you to:
 - Describe table schemas
 - Execute SQL queries
 
+<a href="https://glama.ai/mcp/servers/@bretoreta/mariadb-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bretoreta/mariadb-mcp-server/badge" alt="MariaDB Server MCP server" />
+</a>
+
 ## Security Features
 - **Read-only access Default**: SELECT, SHOW, DESCRIBE, and EXPLAIN
 - **Query validation**: Prevents SQL injection and blocks any data modification attempts


### PR DESCRIPTION
This PR adds a badge for the [MariaDB MCP Server](https://glama.ai/mcp/servers/@bretoreta/mariadb-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@bretoreta/mariadb-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bretoreta/mariadb-mcp-server/badge" alt="MariaDB Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.